### PR TITLE
Fixes unlimited pages in pagination

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -1,0 +1,27 @@
+def REPAGINATE(pages, current_page, max_page_count):
+    if type(pages) == xrange:
+        pages = [i for i in pages]
+
+    current_pages_count = len(pages)
+    if current_pages_count <= max_page_count:
+        return pages
+
+    is_odd = bool(max_page_count%2)
+    page_index = pages.index(current_page)
+    lower_bound = max_page_count - 1
+    upper_bound = current_pages_count - lower_bound
+
+    # Inside first max_page_count-1 elements
+    if page_index <= (lower_bound - 1):
+        return pages[:lower_bound] + ['...', pages[-1]]
+
+    # Inside last max_page_count-1 elements
+    if page_index >= (upper_bound):
+        return [pages[0], '...'] + pages[upper_bound:]
+
+    if not is_odd:
+        lower_bound = page_index - (max_page_count/2) + 2
+    else:
+        lower_bound = page_index - (max_page_count/2) + 1
+    upper_bound = page_index + (max_page_count/2)
+    return [pages[0], '...'] + pages[lower_bound:upper_bound] + ['...', pages[-1]]

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*- #
 from __future__ import unicode_literals
+import os
+import sys
+sys.path.append(os.curdir)
+from functions import *
 
 AUTHOR = u'Og Maciel'
 SITENAME = u'Journal of an Open Sourcee'

--- a/themes/pelican-bootstrap3/templates/includes/pagination.html
+++ b/themes/pelican-bootstrap3/templates/includes/pagination.html
@@ -1,3 +1,7 @@
+{% if MAX_PAGES_IN_PAGINATION is not defined %}
+    {% set MAX_PAGES_IN_PAGINATION = 15 %}
+{% endif %}
+
 {% if articles_page and articles_paginator.num_pages > 1 %}
     {% if USE_PAGER %}
         <ul class="pager">
@@ -22,9 +26,14 @@
             {% else %}
                 <li class="prev disabled"><a href="#">&laquo;</a></li>
             {% endif %}
-            {% for num in range( 1, 1 + articles_paginator.num_pages ) %}
+            {% set repaginated = REPAGINATE(range(1, 1 + articles_paginator.num_pages), articles_page.number, MAX_PAGES_IN_PAGINATION) %}
+            {% for num in repaginated %}
+                {% if num == '...' %}
+                    <li class="disabled"><a href="#">...</a></li>
+                {% else %}
                     <li class="{{ 'active' if num == articles_page.number else '' }}"><a
                             href="{{ SITEURL }}/{{ page_name }}{{ num if num > 1 else '' }}.html">{{ num }}</a></li>
+                {% endif %}
                 {% endfor %}
             {% if articles_page.has_next() %}
                 <li class="next"><a


### PR DESCRIPTION
This commit adds a file called functions.py which will hold any function needed to tweak the theme. In this file is defined a funcition called REPAGINATE, which receives as arguments a list (holding all pages), a page number (current page), and a number (which defines the max number of elements in the pagination). This function returns a new pagination list with limited elements. The number of pages available in the pagination can be adjusted by the MAX_PAGES_IN_PAGINATION variable in the pelicanconf.py file.

The ending result will be somthing as below:
![omaciel-pagination](https://cloud.githubusercontent.com/assets/353311/8072203/2bc716e0-0ee9-11e5-9f7b-2b73ea9fb56b.png)

Note that the algorithm always tries to create a window in which the current page will be centralized. In this example I used `MAX_PAGES_IN_PAGINATION = 15`. Some detailing:
- The first pagination show page 1 to 14 and the last one (total of 15 elements);
- The second example we have the first page (providing an easy way to the user to jump to the first page), pages from 98 to 110 (6 pages before page 104 and 6 pages after page 104) and the last page (providing an easy way to the user to jump to the last page). Summing 15 elements;
- The third example is a mirror of the first one.
