### PR TITLE
Fix ul>li overlapping images

### DIFF
--- a/content/extra/custom.css
+++ b/content/extra/custom.css
@@ -1,0 +1,19 @@
+article div.figure.align-right {
+  margin-left: 20px;
+}
+article div.figure.align-left {
+  margin-right: 20px;
+}
+article div.figure > img {
+  border-radius: 1%;
+}
+article ul.simple {
+  padding-left: 0px;
+}
+article ul.simple li {
+  left: 40px;
+  position: relative;
+}
+.summary img {
+  width: 100%;
+}

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -42,9 +42,11 @@ RELATIVE_URLS = True
 STATIC_PATHS = [
     'extra',
     'images',
+    'extra/custom.css'
 ]
 EXTRA_PATH_METADATA = {
     'extra/robots.txt': {'path': 'robots.txt'},
+    'extra/custom.css': {'path': 'static/custom.css'}
 }
 
 THEME = './themes/pelican-bootstrap3'
@@ -77,3 +79,4 @@ DISQUS_SITENAME = 'journalofanopensourcee'
 
 # Theme serttings
 BOOTSTRAP_THEME = 'united'
+CUSTOM_CSS = 'static/custom.css'


### PR DESCRIPTION
Some `ul>li` elements were overlapping left floated images:

![before](https://cloud.githubusercontent.com/assets/353311/19407755/78952efe-9281-11e6-95fb-49cdb4476b54.png)

After the fix:

![after](https://cloud.githubusercontent.com/assets/353311/19407757/81ebe2ea-9281-11e6-9e00-087b7296dd2a.png)

Also adds a nice `border-radius` to some images.
